### PR TITLE
Basic concurrency support for available public methods - Codium PR-Agent GPT 4

### DIFF
--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -1,0 +1,27 @@
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - review_requested
+
+  issue_comment:
+    types:
+      - created
+      - edited
+jobs:
+  pr_agent_job:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: write
+    name: Run pr agent on every pull request, respond to user comments
+    steps:
+      - name: PR Agent action step
+        id: pragent
+        uses: Codium-ai/pr-agent@main
+        env:
+          OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Sources/General/ImageSource/ImageDataProvider.swift
+++ b/Sources/General/ImageSource/ImageDataProvider.swift
@@ -103,9 +103,6 @@ public struct LocalFileImageDataProvider: ImageDataProvider {
         }
     }
     
-    #if swift(>=5.5)
-    #if canImport(_Concurrency)
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     public var data: Data {
         get async throws {
             try await withCheckedThrowingContinuation { continuation in
@@ -120,8 +117,6 @@ public struct LocalFileImageDataProvider: ImageDataProvider {
             }
         }
     }
-    #endif
-    #endif
 
     /// The URL of the local file on the disk.
     public var contentURL: URL? {

--- a/Sources/General/ImageSource/Source.swift
+++ b/Sources/General/ImageSource/Source.swift
@@ -42,7 +42,10 @@ public enum Source {
         /// The underlying value type of source identifier.
         public typealias Value = UInt
         static private(set) var current: Value = 0
+        
+        // Not thread safe. Expected to be always called on the main thread.
         static func next() -> Value {
+            assert(Thread.isMainThread, "The identifier `next()` should only be called on main thread.")
             current += 1
             return current
         }

--- a/Sources/General/KingfisherManager.swift
+++ b/Sources/General/KingfisherManager.swift
@@ -803,8 +803,12 @@ extension KingfisherManager {
                         continuation.resume(with: result)
                     }
                 )
-                Task {
-                    await task.setTask(downloadTask)
+                if Task.isCancelled {
+                    downloadTask?.cancel()
+                } else {
+                    Task {
+                        await task.setTask(downloadTask)
+                    }
                 }
             }
         } onCancel: {

--- a/Sources/Networking/ImageDownloader.swift
+++ b/Sources/Networking/ImageDownloader.swift
@@ -472,6 +472,74 @@ open class ImageDownloader {
     }
 }
 
+// Concurrency
+extension ImageDownloader {
+    /// Downloads an image with a URL and option. Invoked internally by Kingfisher. Subclasses must invoke super.
+    ///
+    /// - Parameters:
+    ///   - url: Target URL.
+    ///   - options: The options could control download behavior. See `KingfisherOptionsInfo`.
+    /// - Returns: The image loading result.
+    public func downloadImage(
+        with url: URL,
+        options: KingfisherParsedOptionsInfo
+    ) async throws -> ImageLoadingResult {
+        let task = CancellationDownloadTask()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                let downloadTask = downloadImage(with: url, options: options) { result in
+                    continuation.resume(with: result)
+                }
+                if Task.isCancelled {
+                    downloadTask?.cancel()
+                } else {
+                    Task {
+                        await task.setTask(downloadTask)
+                    }
+                }
+            }
+        } onCancel: {
+            Task {
+                await task.task?.cancel()
+            }
+        }
+    }
+    
+    /// Downloads an image with a URL and option.
+    ///
+    /// - Parameters:
+    ///   - url: Target URL.
+    ///   - options: The options could control download behavior. See `KingfisherOptionsInfo`.
+    ///   - progressBlock: Called when the download progress updated. This block will be always be called in main queue.
+    /// - Returns: The image loading result.
+    public func downloadImage(
+        with url: URL,
+        options: KingfisherOptionsInfo? = nil,
+        progressBlock: DownloadProgressBlock? = nil
+    ) async throws -> ImageLoadingResult
+    {
+        var info = KingfisherParsedOptionsInfo(options)
+        if let block = progressBlock {
+            info.onDataReceived = (info.onDataReceived ?? []) + [ImageLoadingProgressSideEffect(block)]
+        }
+        return try await downloadImage(with: url, options: info)
+    }
+    
+    /// Downloads an image with a URL and option.
+    ///
+    /// - Parameters:
+    ///   - url: Target URL.
+    ///   - options: The options could control download behavior. See `KingfisherOptionsInfo`.
+    /// - Returns: The image loading result.
+    public func downloadImage(
+        with url: URL,
+        options: KingfisherOptionsInfo? = nil
+    ) async throws -> ImageLoadingResult
+    {
+        return try await downloadImage(with: url, options: KingfisherParsedOptionsInfo(options))
+    }
+}
+
 // MARK: Cancelling Task
 extension ImageDownloader {
 

--- a/Sources/Networking/ImageDownloader.swift
+++ b/Sources/Networking/ImageDownloader.swift
@@ -87,6 +87,13 @@ public struct DownloadTask {
     }
 }
 
+actor CancellationDownloadTask {
+    var task: DownloadTask?
+    func setTask(_ task: DownloadTask?) {
+        self.task = task
+    }
+}
+
 extension DownloadTask {
     enum WrappedTask {
         case download(DownloadTask)

--- a/Sources/Networking/RedirectHandler.swift
+++ b/Sources/Networking/RedirectHandler.swift
@@ -30,6 +30,7 @@ import Foundation
 public protocol ImageDownloadRedirectHandler {
 
     /// The `ImageDownloadRedirectHandler` contained will be used to change the request before redirection.
+    /// 
     /// This is the posibility you can modify the image download request during redirection. You can modify the
     /// request for some customizing purpose, such as adding auth token to the header, do basic HTTP auth or
     /// something like url mapping.
@@ -43,7 +44,7 @@ public protocol ImageDownloadRedirectHandler {
     ///   - task: The current `SessionDataTask` which triggers this redirect.
     ///   - response: The response received during redirection.
     ///   - newRequest: The request for redirection which can be modified.
-    ///   - completionHandler: A closure for being called with modified request.
+    /// - Returns: The modified requst.
     func handleHTTPRedirection(
         for task: SessionDataTask,
         response: HTTPURLResponse,

--- a/Sources/Networking/SessionDelegate.swift
+++ b/Sources/Networking/SessionDelegate.swift
@@ -244,21 +244,15 @@ extension SessionDelegate: URLSessionDataDelegate {
         _ session: URLSession,
         task: URLSessionTask,
         willPerformHTTPRedirection response: HTTPURLResponse,
-        newRequest request: URLRequest,
-        completionHandler: @escaping (URLRequest?) -> Void)
+        newRequest request: URLRequest
+    ) async -> URLRequest?
     {
         guard let sessionDataTask = self.task(for: task),
               let redirectHandler = Array(sessionDataTask.callbacks).last?.options.redirectHandler else
         {
-            completionHandler(request)
-            return
+            return request
         }
-        
-        redirectHandler.handleHTTPRedirection(
-            for: sessionDataTask,
-            response: response,
-            newRequest: request,
-            completionHandler: completionHandler)
+        return await redirectHandler.handleHTTPRedirection(for: sessionDataTask, response: response, newRequest: request)
     }
 
     private func onCompleted(task: URLSessionTask, result: Result<(Data, URLResponse?), KingfisherError>) {

--- a/Sources/Views/AnimatedImageView.swift
+++ b/Sources/Views/AnimatedImageView.swift
@@ -325,10 +325,8 @@ open class AnimatedImageView: UIImageView {
             duration = 1.0 / TimeInterval(preferredFramesPerSecond)
         }
 
-        animator.shouldChangeFrame(with: duration) { [weak self] hasNewFrame in
-            if hasNewFrame {
-                self?.layer.setNeedsDisplay()
-            }
+        if animator.shouldChangeFrame(with: duration) {
+            layer.setNeedsDisplay()
         }
     }
 }
@@ -545,15 +543,15 @@ extension AnimatedImageView {
             }
         }
 
-        func shouldChangeFrame(with duration: CFTimeInterval, handler: (Bool) -> Void) {
+        func shouldChangeFrame(with duration: CFTimeInterval) -> Bool {
             incrementTimeSinceLastFrameChange(with: duration)
 
             if currentFrameDuration > timeSinceLastFrameChange {
-                handler(false)
+                return false
             } else {
                 resetTimeSinceLastFrameChange()
                 incrementCurrentFrameIndex()
-                handler(true)
+                return true
             }
         }
 

--- a/Tests/KingfisherTests/ImageDataProviderTests.swift
+++ b/Tests/KingfisherTests/ImageDataProviderTests.swift
@@ -51,9 +51,6 @@ class ImageDataProviderTests: XCTestCase {
         waitForExpectations(timeout: 1, handler: nil)
     }
     
-    #if swift(>=5.5)
-    #if canImport(_Concurrency)
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func testLocalFileImageDataProviderAsync() async {
         let fm = FileManager.default
         let document = try! fm.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
@@ -70,9 +67,7 @@ class ImageDataProviderTests: XCTestCase {
         XCTAssertEqual(value, testImageData)
         try! fm.removeItem(at: fileURL)
     }
-    #endif
-    #endif
-    
+
     func testLocalFileImageDataProviderMainQueue() {
         let fm = FileManager.default
         let document = try! fm.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
@@ -92,10 +87,7 @@ class ImageDataProviderTests: XCTestCase {
 
         XCTAssertTrue(called)
     }
-    
-    #if swift(>=5.5)
-    #if canImport(_Concurrency)
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+
     func testLocalFileImageDataProviderMainQueueAsync() async {
         let fm = FileManager.default
         let document = try! fm.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
@@ -114,8 +106,6 @@ class ImageDataProviderTests: XCTestCase {
 
         XCTAssertTrue(called)
     }
-    #endif
-    #endif
     
     func testLocalFileCacheKey() {
         let url1 = URL(string: "file:///Users/onevcat/Library/Developer/CoreSimulator/Devices/ABC/data/Containers/Bundle/Application/DEF/Kingfisher-Demo.app/images/kingfisher-1.jpg")!

--- a/Tests/KingfisherTests/KingfisherOptionsInfoTests.swift
+++ b/Tests/KingfisherTests/KingfisherOptionsInfoTests.swift
@@ -153,7 +153,9 @@ class TestModifier: ImageDownloadRequestModifier {
 }
 
 class TestRedirectHandler: ImageDownloadRedirectHandler {
-    func handleHTTPRedirection(for task: SessionDataTask, response: HTTPURLResponse, newRequest: URLRequest, completionHandler: @escaping (URLRequest?) -> Void) {
-        completionHandler(newRequest)
+    func handleHTTPRedirection(
+        for task: Kingfisher.SessionDataTask, response: HTTPURLResponse, newRequest: URLRequest
+    ) async -> URLRequest? {
+        newRequest
     }
 }


### PR DESCRIPTION
## **Type**
enhancement, bug_fix


___

## **Description**
- Added async versions of methods in `ImageCache`, `KingfisherManager`, and `ImageDownloader` for better compatibility with modern Swift concurrency.
- Improved error handling in `ImageCache.removeImage` method.
- Added thread safety assertion in `Source.Identifier.next()`.
- Simplified frame change checking logic in `AnimatedImageView`.
- Added async test cases across various components for better test coverage.

___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>ImageCache.swift</strong><dd><code>Add Async Methods and Improve Error Handling in ImageCache</code></dd></summary>
<hr>

Sources/Cache/ImageCache.swift
<li>Added async versions of <code>store</code>, <code>removeImage</code>, <code>retrieveImage</code>, <code>clearCache</code>, <br><code>clearDiskCache</code>, <code>cleanExpiredCache</code>, and <code>cleanExpiredDiskCache</code> methods.<br> <li> Modified <code>removeImage</code> method to handle errors properly.<br> <li> Removed unnecessary async disk storage size property.<br>


</details>
    

  </td>
  <td><a href="https://github.com/onevcat/Kingfisher-Review-Sample/pull/5/files#diff-907250578ecd8a7a1674f252acae0d2955ed49d6507cce50c9e1555e5ebd1887">+219/-21</a></td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ImageDataProvider.swift</strong><dd><code>Add Async Support to ImageDataProvider</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/General/ImageSource/ImageDataProvider.swift
<li>Added async version of <code>data</code> property in <code>LocalFileImageDataProvider</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/onevcat/Kingfisher-Review-Sample/pull/5/files#diff-b1a7852efa06ef93270c8f2a0b8034554e3f6fe9ab4f4ae73aabda3e6d5c4a23">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>KingfisherManager.swift</strong><dd><code>Add Async Methods to KingfisherManager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/General/KingfisherManager.swift
- Added async versions of `retrieveImage` methods.



</details>
    

  </td>
  <td><a href="https://github.com/onevcat/Kingfisher-Review-Sample/pull/5/files#diff-385bb415190ee94811b0a7294c6e44116b83d355444f197ce3c8894301c2a01a">+111/-0</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ImageDownloader.swift</strong><dd><code>Add Async Download Methods and Improve Task Cancellation Handling</code></dd></summary>
<hr>

Sources/Networking/ImageDownloader.swift
<li>Added async versions of <code>downloadImage</code> methods.<br> <li> Introduced <code>CancellationDownloadTask</code> to handle task cancellation.<br>


</details>
    

  </td>
  <td><a href="https://github.com/onevcat/Kingfisher-Review-Sample/pull/5/files#diff-b1f354ec0833c819b567b6a6600e4e10d257135f5ff9f773b342a6cc4b734cb4">+75/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>RedirectHandler.swift</strong><dd><code>Support Async/Await in Redirect Handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/Networking/RedirectHandler.swift
- Modified `handleHTTPRedirection` to support async/await pattern.



</details>
    

  </td>
  <td><a href="https://github.com/onevcat/Kingfisher-Review-Sample/pull/5/files#diff-d27824f0b695d0a74d6c196a2c2116a524d0126820d8fd982090821e77360d1f">+13/-10</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>SessionDelegate.swift</strong><dd><code>Use Async Redirect Handling in SessionDelegate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/Networking/SessionDelegate.swift
<li>Updated <code>willPerformHTTPRedirection</code> to use async version of <br><code>handleHTTPRedirection</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/onevcat/Kingfisher-Review-Sample/pull/5/files#diff-c8e13fc13aec6d14931b1afb8ee176bab1bc365e3cd9043eea87a8bc9d10dc93">+4/-10</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>AnimatedImageView.swift</strong><dd><code>Simplify Frame Change Logic in AnimatedImageView</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/Views/AnimatedImageView.swift
- Simplified frame change checking logic in `displayLayer`.



</details>
    

  </td>
  <td><a href="https://github.com/onevcat/Kingfisher-Review-Sample/pull/5/files#diff-c4f0f8dea3866536b4cc94b4d2dd74c89ae02a67474d1a957adfb9d0775b48d7">+5/-7</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Bug_fix
</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>Source.swift</strong><dd><code>Improve Thread Safety in Source Identifier Generation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/General/ImageSource/Source.swift
- Added thread safety assertion in `Source.Identifier.next()`.



</details>
    

  </td>
  <td><a href="https://github.com/onevcat/Kingfisher-Review-Sample/pull/5/files#diff-44d96dfc833523b15e1b34b096a5f1b09901ee7c4effb6fb279162309322cdd6">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Tests
</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>ImageCacheTests.swift</strong><dd><code>Add Async Test Cases for ImageCache</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Tests/KingfisherTests/ImageCacheTests.swift
- Added async test cases for various `ImageCache` operations.



</details>
    

  </td>
  <td><a href="https://github.com/onevcat/Kingfisher-Review-Sample/pull/5/files#diff-242a0ec12752d80a6bc09f05c66cec240cfccf9aaab938a6376ba3cadcdb9043">+191/-21</a></td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ImageDataProviderTests.swift</strong><dd><code>Add Async Test Cases for ImageDataProvider</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Tests/KingfisherTests/ImageDataProviderTests.swift
- Added async test cases for `LocalFileImageDataProvider`.



</details>
    

  </td>
  <td><a href="https://github.com/onevcat/Kingfisher-Review-Sample/pull/5/files#diff-61141f557a03ae9ec01b7486e80f328c817421cdb9cacd215df7467e1ac44dac">+2/-12</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ImageDownloaderTests.swift</strong><dd><code>Add Async Test Cases for ImageDownloader</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Tests/KingfisherTests/ImageDownloaderTests.swift
- Added async test cases for image downloading.



</details>
    

  </td>
  <td><a href="https://github.com/onevcat/Kingfisher-Review-Sample/pull/5/files#diff-92996a35d6651d6e2ae2a758031451b2c571518d1855deede8244d9e00e70c22">+33/-1</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>KingfisherManagerTests.swift</strong><dd><code>Add Async Test Cases and Cancellation Testing Utility in </code><br><code>KingfisherManagerTests</code></dd></summary>
<hr>

Tests/KingfisherTests/KingfisherManagerTests.swift
<li>Added async test cases for image retrieval.<br> <li> Added a utility actor <code>CallingChecker</code> for testing cancellation <br>behavior.<br>


</details>
    

  </td>
  <td><a href="https://github.com/onevcat/Kingfisher-Review-Sample/pull/5/files#diff-67c99e8760eff938a87effeed76eecac51b3d0270e82eeb925f673d7f70cd94a">+81/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>KingfisherOptionsInfoTests.swift</strong><dd><code>Update Test Utility to Support Async/Await</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Tests/KingfisherTests/KingfisherOptionsInfoTests.swift
- Modified `TestRedirectHandler` to support async/await pattern.



</details>
    

  </td>
  <td><a href="https://github.com/onevcat/Kingfisher-Review-Sample/pull/5/files#diff-44b307fb4f5cd593e50a1ed0e50baa391a051df059f9ab28d3202709498c650b">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes
</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_agent.yml</strong><dd><code>Introduce PR Agent GitHub Actions Workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr_agent.yml
- Added a new GitHub Actions workflow for PR Agent.



</details>
    

  </td>
  <td><a href="https://github.com/onevcat/Kingfisher-Review-Sample/pull/5/files#diff-fc2b2ed01cad745cb09e9c20e7c91db7f4f1eb9796abb84bbdce7dd0f77dace8">+27/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

