### PR TITLE
Use the unretained version of CGImage to avoid racing - Codium PR-Agent GPT 4

### DIFF
--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -1,0 +1,27 @@
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - review_requested
+
+  issue_comment:
+    types:
+      - created
+      - edited
+jobs:
+  pr_agent_job:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: write
+    name: Run pr agent on every pull request, respond to user comments
+    steps:
+      - name: PR Agent action step
+        id: pragent
+        uses: Codium-ai/pr-agent@main
+        env:
+          OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Sources/Image/ImageDrawing.swift
+++ b/Sources/Image/ImageDrawing.swift
@@ -567,6 +567,25 @@ extension CGImage {
         }
         return decodedImageRef
     }
+    
+    static func create(ref: CGImage) -> CGImage? {
+        guard let space = ref.colorSpace, let provider = ref.dataProvider else {
+            return nil
+        }
+        return CGImage(
+            width: ref.width,
+            height: ref.height,
+            bitsPerComponent: ref.bitsPerComponent,
+            bitsPerPixel: ref.bitsPerPixel,
+            bytesPerRow: ref.bytesPerRow,
+            space: space,
+            bitmapInfo: ref.bitmapInfo,
+            provider: provider,
+            decode: ref.decode,
+            shouldInterpolate: ref.shouldInterpolate,
+            intent: ref.renderingIntent
+        )
+    }
 }
 
 extension KingfisherWrapper where Base: KFCrossPlatformImage {

--- a/Sources/Views/AnimatedImageView.swift
+++ b/Sources/Views/AnimatedImageView.swift
@@ -524,13 +524,10 @@ extension AnimatedImageView {
             self.maxFrameCount = count
             self.maxRepeatCount = repeatCount
             self.preloadQueue = preloadQueue
-            
-            GraphicsContext.begin(size: imageSize, scale: imageScale)
         }
         
         deinit {
             resetAnimatedFrames()
-            GraphicsContext.end()
         }
 
         /// Gets the image frame of a given index.
@@ -598,13 +595,11 @@ extension AnimatedImageView {
                 // To get a workaround, create another image ref and use that to create the final image. This leads to
                 // some performance loss, but there is little we can do.
                 // https://github.com/onevcat/Kingfisher/issues/1844
-                guard let context = GraphicsContext.current(size: imageSize, scale: imageScale, inverting: true, cgImage: cgImage),
-                      let decodedImageRef = cgImage.decoded(on: context, scale: imageScale)
-                else {
+                guard let unretainedImage = CGImage.create(ref: cgImage) else {
                     return KFCrossPlatformImage(cgImage: cgImage)
                 }
                 
-                return KFCrossPlatformImage(cgImage: decodedImageRef)
+                return KFCrossPlatformImage(cgImage: unretainedImage)
             } else {
                 let image = KFCrossPlatformImage(cgImage: cgImage)
                 if backgroundDecode {
@@ -730,3 +725,5 @@ class SafeArray<Element> {
 }
 #endif
 #endif
+
+

--- a/Sources/Views/AnimatedImageView.swift
+++ b/Sources/Views/AnimatedImageView.swift
@@ -595,6 +595,7 @@ extension AnimatedImageView {
                 // To get a workaround, create another image ref and use that to create the final image. This leads to
                 // some performance loss, but there is little we can do.
                 // https://github.com/onevcat/Kingfisher/issues/1844
+                // https://github.com/onevcat/Kingfisher/pulls/2194
                 guard let unretainedImage = CGImage.create(ref: cgImage) else {
                     return KFCrossPlatformImage(cgImage: cgImage)
                 }


### PR DESCRIPTION
## **Type**
enhancement, bug_fix


___

## **Description**
- Added a new static function `create(ref: CGImage)` in `ImageDrawing.swift` to create `CGImage` instances safely, addressing potential race conditions.
- Refactored `AnimatedImageView.swift` to use the new `CGImage.create(ref:)` method for safer image handling and removed unnecessary GraphicsContext management.
- Introduced a GitHub Actions workflow in `.github/workflows/pr_agent.yml` to automate PR reviews and interactions using the PR Agent.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ImageDrawing.swift</strong><dd><code>Add Safe CGImage Creation to Avoid Race Conditions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/Image/ImageDrawing.swift
<li>Added a static function <code>create(ref: CGImage)</code> to safely create a new <br><code>CGImage</code> instance to avoid race conditions.<br>


</details>
    

  </td>
  <td><a href="https://github.com/onevcat/Kingfisher-Review-Sample/pull/7/files#diff-ba4fca5806c5112338bf215a6c3574ba3bfd100635f79b39a52c895ddccc71df">+19/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>pr_agent.yml</strong><dd><code>Introduce PR Agent GitHub Actions Workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr_agent.yml
<li>Introduced a new GitHub Actions workflow to run PR Agent on pull <br>requests and issue comments.<br>


</details>
    

  </td>
  <td><a href="https://github.com/onevcat/Kingfisher-Review-Sample/pull/7/files#diff-fc2b2ed01cad745cb09e9c20e7c91db7f4f1eb9796abb84bbdce7dd0f77dace8">+27/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Bug_fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AnimatedImageView.swift</strong><dd><code>Refactor AnimatedImageView to Use Safe CGImage Creation</code>&nbsp; &nbsp; </dd></summary>
<hr>

Sources/Views/AnimatedImageView.swift
<li>Removed GraphicsContext management in <code>AnimatedImageView</code> initializer <br>and deinitializer.<br> <li> Replaced image decoding logic with a call to the newly added <br><code>CGImage.create(ref:)</code> to mitigate race conditions.<br> <li> Added reference to PR #2194 in comments for context.<br>


</details>
    

  </td>
  <td><a href="https://github.com/onevcat/Kingfisher-Review-Sample/pull/7/files#diff-c4f0f8dea3866536b4cc94b4d2dd74c89ae02a67474d1a957adfb9d0775b48d7">+5/-7</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

