### PR TITLE
Add download method with cache checking - Codium PR-Agent GPT 4

### DIFF
--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -1,0 +1,27 @@
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - review_requested
+
+  issue_comment:
+    types:
+      - created
+      - edited
+jobs:
+  pr_agent_job:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: write
+    name: Run pr agent on every pull request, respond to user comments
+    steps:
+      - name: PR Agent action step
+        id: pragent
+        uses: Codium-ai/pr-agent@main
+        env:
+          OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Demo/Demo/Kingfisher-Demo/ViewControllers/NormalLoadingViewController.swift
+++ b/Demo/Demo/Kingfisher-Demo/ViewControllers/NormalLoadingViewController.swift
@@ -64,6 +64,9 @@ extension NormalLoadingViewController {
             .onSuccess { print($0) }
             .onFailure { err in print("Error: \(err)") }
             .set(to: imageView)
+        
+        // Also ensure download
+        KingfisherManager.shared.performDownloadIfNecessary(source: .network(url))
     }
     
     override func collectionView(

--- a/Sources/General/KingfisherManager.swift
+++ b/Sources/General/KingfisherManager.swift
@@ -342,7 +342,19 @@ public class KingfisherManager {
             result in
             handler(currentSource: source, result: result)
         }
-
+    }
+    
+    public func performDownloadIfNecessary(source: Source) {
+        downloadIfNotCached(with: source)
+    }
+    
+    private func downloadIfNotCached(with source: Source) {
+        let cached = cache.isCached(forKey: source.cacheKey)
+        if cached {
+            downloader.downloadImage(with: source.url!, options: [])
+        } else {
+            // Do nothing since already cached.
+        }
     }
     
     private func retrieveImage(


### PR DESCRIPTION
## **Type**
enhancement, other


___

## **Description**
- Added a new method in `KingfisherManager` to check if an image is cached before attempting to download it, enhancing efficiency.
- Ensured images are downloaded only if not already cached in `NormalLoadingViewController`.
- Integrated a new GitHub Actions workflow to automate PR Agent operations on pull requests and issue comments.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NormalLoadingViewController.swift</strong><dd><code>Ensure Image Download if Not Cached</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Demo/Demo/Kingfisher-Demo/ViewControllers/NormalLoadingViewController.swift
<li>Added a call to <code>performDownloadIfNecessary</code> to ensure images are <br>downloaded if not cached.<br>


</details>
    

  </td>
  <td><a href="https://github.com/onevcat/Kingfisher-Review-Sample/pull/9/files#diff-ff72440b6d583b539a8681a393f2f2faa11c7586a131e8822ffced323eede350">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>KingfisherManager.swift</strong><dd><code>Add Cache Checking Before Download</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/General/KingfisherManager.swift
<li>Introduced <code>performDownloadIfNecessary</code> method to check cache before <br>downloading.<br> <li> Added a private method <code>downloadIfNotCached</code> to handle the download <br>logic based on cache status.<br>


</details>
    

  </td>
  <td><a href="https://github.com/onevcat/Kingfisher-Review-Sample/pull/9/files#diff-385bb415190ee94811b0a7294c6e44116b83d355444f197ce3c8894301c2a01a">+13/-1</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Other</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_agent.yml</strong><dd><code>Integrate PR Agent GitHub Actions Workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr_agent.yml
<li>Added a new GitHub Actions workflow for PR Agent to run on PR events <br>and issue comments.<br>


</details>
    

  </td>
  <td><a href="https://github.com/onevcat/Kingfisher-Review-Sample/pull/9/files#diff-fc2b2ed01cad745cb09e9c20e7c91db7f4f1eb9796abb84bbdce7dd0f77dace8">+27/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

