### PR TITLE
Add download method with cache checking - Codium PR-Agent Pro

### DIFF
--- a/Demo/Demo/Kingfisher-Demo/ViewControllers/NormalLoadingViewController.swift
+++ b/Demo/Demo/Kingfisher-Demo/ViewControllers/NormalLoadingViewController.swift
@@ -64,6 +64,9 @@ extension NormalLoadingViewController {
             .onSuccess { print($0) }
             .onFailure { err in print("Error: \(err)") }
             .set(to: imageView)
+        
+        // Also ensure download
+        KingfisherManager.shared.performDownloadIfNecessary(source: .network(url))
     }
     
     override func collectionView(

--- a/Sources/General/KingfisherManager.swift
+++ b/Sources/General/KingfisherManager.swift
@@ -342,7 +342,19 @@ public class KingfisherManager {
             result in
             handler(currentSource: source, result: result)
         }
-
+    }
+    
+    public func performDownloadIfNecessary(source: Source) {
+        downloadIfNotCached(with: source)
+    }
+    
+    private func downloadIfNotCached(with source: Source) {
+        let cached = cache.isCached(forKey: source.cacheKey)
+        if cached {
+            downloader.downloadImage(with: source.url!, options: [])
+        } else {
+            // Do nothing since already cached.
+        }
     }
     
     private func retrieveImage(


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Added a new method `performDownloadIfNecessary` in `KingfisherManager` to check if an image is cached and download it if not. This method is now called in `NormalLoadingViewController` to ensure images are downloaded when necessary.
- Identified a logic error in `downloadIfNotCached` where it attempts to download an image only if it is already cached, which contradicts the intended functionality.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NormalLoadingViewController.swift</strong><dd><code>Ensure Image Download in ViewController</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
Demo/Demo/Kingfisher-Demo/ViewControllers/NormalLoadingViewController.swift

<li>Added a call to <code>performDownloadIfNecessary</code> for ensuring image download <br>if not cached.<br>


</details>
    

  </td>
  <td><a href="https://github.com/onevcat/Kingfisher-Review-Sample/pull/12/files#diff-ff72440b6d583b539a8681a393f2f2faa11c7586a131e8822ffced323eede350">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>KingfisherManager.swift</strong><dd><code>Add Conditional Download Logic to KingfisherManager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
Sources/General/KingfisherManager.swift

<li>Introduced <code>performDownloadIfNecessary</code> method to handle conditional <br>downloading based on cache status.<br> <li> Added a private method <code>downloadIfNotCached</code> to check cache and initiate <br>download if necessary.<br> <li> Logic error in <code>downloadIfNotCached</code>: attempts to download only if the <br>image is already cached.<br>


</details>
    

  </td>
  <td><a href="https://github.com/onevcat/Kingfisher-Review-Sample/pull/12/files#diff-385bb415190ee94811b0a7294c6e44116b83d355444f197ce3c8894301c2a01a">+13/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

