### PR TITLE
Use the unretained version of CGImage to avoid racing - Codium PR-Agent Pro

### DIFF
--- a/Sources/Image/ImageDrawing.swift
+++ b/Sources/Image/ImageDrawing.swift
@@ -567,6 +567,25 @@ extension CGImage {
         }
         return decodedImageRef
     }
+    
+    static func create(ref: CGImage) -> CGImage? {
+        guard let space = ref.colorSpace, let provider = ref.dataProvider else {
+            return nil
+        }
+        return CGImage(
+            width: ref.width,
+            height: ref.height,
+            bitsPerComponent: ref.bitsPerComponent,
+            bitsPerPixel: ref.bitsPerPixel,
+            bytesPerRow: ref.bytesPerRow,
+            space: space,
+            bitmapInfo: ref.bitmapInfo,
+            provider: provider,
+            decode: ref.decode,
+            shouldInterpolate: ref.shouldInterpolate,
+            intent: ref.renderingIntent
+        )
+    }
 }
 
 extension KingfisherWrapper where Base: KFCrossPlatformImage {

--- a/Sources/Views/AnimatedImageView.swift
+++ b/Sources/Views/AnimatedImageView.swift
@@ -524,13 +524,10 @@ extension AnimatedImageView {
             self.maxFrameCount = count
             self.maxRepeatCount = repeatCount
             self.preloadQueue = preloadQueue
-            
-            GraphicsContext.begin(size: imageSize, scale: imageScale)
         }
         
         deinit {
             resetAnimatedFrames()
-            GraphicsContext.end()
         }
 
         /// Gets the image frame of a given index.
@@ -598,13 +595,11 @@ extension AnimatedImageView {
                 // To get a workaround, create another image ref and use that to create the final image. This leads to
                 // some performance loss, but there is little we can do.
                 // https://github.com/onevcat/Kingfisher/issues/1844
-                guard let context = GraphicsContext.current(size: imageSize, scale: imageScale, inverting: true, cgImage: cgImage),
-                      let decodedImageRef = cgImage.decoded(on: context, scale: imageScale)
-                else {
+                guard let unretainedImage = CGImage.create(ref: cgImage) else {
                     return KFCrossPlatformImage(cgImage: cgImage)
                 }
                 
-                return KFCrossPlatformImage(cgImage: decodedImageRef)
+                return KFCrossPlatformImage(cgImage: unretainedImage)
             } else {
                 let image = KFCrossPlatformImage(cgImage: cgImage)
                 if backgroundDecode {
@@ -730,3 +725,5 @@ class SafeArray<Element> {
 }
 #endif
 #endif
+
+

--- a/Sources/Views/AnimatedImageView.swift
+++ b/Sources/Views/AnimatedImageView.swift
@@ -595,6 +595,7 @@ extension AnimatedImageView {
                 // To get a workaround, create another image ref and use that to create the final image. This leads to
                 // some performance loss, but there is little we can do.
                 // https://github.com/onevcat/Kingfisher/issues/1844
+                // https://github.com/onevcat/Kingfisher/pulls/2194
                 guard let unretainedImage = CGImage.create(ref: cgImage) else {
                     return KFCrossPlatformImage(cgImage: cgImage)
                 }


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Introduced a new method `CGImage.create(ref:)` in `ImageDrawing.swift` for creating a `CGImage` instance without retaining the original image's memory, enhancing memory management.
- Refactored `AnimatedImageView.swift` to use the new `CGImage.create(ref:)` method for safer and more efficient image handling, addressing potential race conditions and memory retention issues.
- Removed outdated and unnecessary use of `GraphicsContext` in `AnimatedImageView.swift`, streamlining the codebase.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ImageDrawing.swift</strong><dd><code>Add Safe CGImage Creation to Avoid Retention</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
Sources/Image/ImageDrawing.swift

<li>Added a new static function <code>create(ref: CGImage)</code> to safely create a <br>new <code>CGImage</code> instance from an existing one without retaining the <br>original image's memory.<br>


</details>
    

  </td>
  <td><a href="https://github.com/onevcat/Kingfisher-Review-Sample/pull/13/files#diff-ba4fca5806c5112338bf215a6c3574ba3bfd100635f79b39a52c895ddccc71df">+19/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>AnimatedImageView.swift</strong><dd><code>Refactor Image Handling for Better Memory Management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
Sources/Views/AnimatedImageView.swift

<li>Removed the use of <code>GraphicsContext</code> for image decoding to avoid <br>potential memory retention and race conditions.<br> <li> Introduced usage of the newly added <code>CGImage.create(ref:)</code> for safer <br>image handling.<br> <li> Minor cleanup by removing unnecessary comments and adding a reference <br>to the PR in comments.<br>


</details>
    

  </td>
  <td><a href="https://github.com/onevcat/Kingfisher-Review-Sample/pull/13/files#diff-c4f0f8dea3866536b4cc94b4d2dd74c89ae02a67474d1a957adfb9d0775b48d7">+5/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

